### PR TITLE
LinearDCT

### DIFF
--- a/torch_dct/__init__.py
+++ b/torch_dct/__init__.py
@@ -1,1 +1,1 @@
-from ._dct import dct, idct, dct1, idct1, dct_2d, idct_2d, dct_3d, idct_3d
+from ._dct import dct, idct, dct1, idct1, dct_2d, idct_2d, dct_3d, idct_3d, LinearDCT, apply_linear_2d, apply_linear_3d

--- a/torch_dct/_dct.py
+++ b/torch_dct/_dct.py
@@ -222,3 +222,14 @@ def apply_linear_3d(x, linear_layer):
     X2 = linear_layer(X1.transpose(-1, -2))
     X3 = linear_layer(X2.transpose(-1, -3))
     return X3.transpose(-1, -3).transpose(-1, -2)
+
+if __name__ == '__main__':
+    x = torch.Tensor(1000,4096)
+    x.normal_(0,1)
+    linear_dct = LinearDCT(4096, 'dct')
+    error = torch.abs(dct(x) - linear_dct(x))
+    assert error.max() < 1e-3, (error, error.max())
+    linear_idct = LinearDCT(4096, 'idct')
+    error = torch.abs(idct(x) - linear_idct(x))
+    assert error.max() < 1e-3, (error, error.max())
+

--- a/torch_dct/test/test_lineardct.py
+++ b/torch_dct/test/test_lineardct.py
@@ -1,0 +1,100 @@
+import torch_dct
+import scipy.fftpack as fftpack
+import numpy as np
+import torch
+
+np.random.seed(1)
+
+EPS = 1e-3
+# THIS IS NOT HOW THESE LAYERS SHOULD BE USED IN PRACTICE
+# only written this way for testing convenience
+dct1 = lambda x: torch_dct.LinearDCT(x.size(1), type='dct1')(x).data
+idct1 = lambda x: torch_dct.LinearDCT(x.size(1), type='idct1')(x).data
+def dct(x, norm=None):
+    return torch_dct.LinearDCT(x.size(1), type='dct', norm=norm)(x).data
+def idct(x, norm=None):
+    return torch_dct.LinearDCT(x.size(1), type='idct', norm=norm)(x).data
+
+dct_2d = lambda x: torch_dct.apply_linear_2d(x, torch_dct.LinearDCT(x.size(1), type='dct')).data
+dct_3d = lambda x: torch_dct.apply_linear_3d(x, torch_dct.LinearDCT(x.size(1), type='dct')).data
+idct_2d = lambda x: torch_dct.apply_linear_2d(x, torch_dct.LinearDCT(x.size(1), type='idct')).data
+idct_3d = lambda x: torch_dct.apply_linear_3d(x, torch_dct.LinearDCT(x.size(1), type='idct')).data
+
+def test_dct1():
+    for N in [2, 5, 32, 111]:
+        x = np.random.normal(size=(1, N,))
+        ref = fftpack.dct(x, type=1)
+        act = dct1(torch.tensor(x).float()).numpy()
+        assert np.abs(ref - act).max() < EPS, ref
+
+    for d in [2, 3, 4]:
+        x = np.random.normal(size=(2,) * d)
+        ref = fftpack.dct(x, type=1)
+        act = dct1(torch.tensor(x).float()).numpy()
+        assert np.abs(ref - act).max() < EPS, ref
+
+
+def test_idct1():
+    for N in [2, 5, 32, 111]:
+        x = np.random.normal(size=(1, N))
+        X = dct1(torch.tensor(x).float())
+        y = idct1(X).numpy()
+        assert np.abs(x - y).max() < EPS, x
+
+
+def test_dct():
+    for norm in [None, 'ortho']:
+        for N in [2, 3, 5, 32, 111]:
+            x = np.random.normal(size=(1, N,))
+            ref = fftpack.dct(x, type=2, norm=norm)
+            act = dct(torch.tensor(x).float(), norm=norm).numpy()
+            assert np.abs(ref - act).max() < EPS, (norm, N)
+
+        for d in [2, 3, 4, 11]:
+            x = np.random.normal(size=(2,) * d)
+            ref = fftpack.dct(x, type=2, norm=norm)
+            act = dct(torch.tensor(x).float(), norm=norm).numpy()
+            assert np.abs(ref - act).max() < EPS, (norm, d)
+
+
+def test_idct():
+    for norm in [None, 'ortho']:
+        for N in [5, 2, 32, 111]:
+            x = np.random.normal(size=(1, N))
+            X = dct(torch.tensor(x).float(), norm=norm)
+            y = idct(X, norm=norm).numpy()
+            assert np.abs(x - y).max() < EPS, x
+
+def test_dct_2d():
+    for N1 in [2, 5, 32]:
+        x = np.random.normal(size=(1, N1, N1))
+        ref = fftpack.dct(x, axis=2, type=2)
+        ref = fftpack.dct(ref, axis=1, type=2)
+        act = dct_2d(torch.tensor(x).float()).numpy()
+        assert np.abs(ref - act).max() < EPS, (ref, act)
+
+
+def test_idct_2d():
+    for N1 in [2, 5, 32]:
+        x = np.random.normal(size=(1, N1, N1))
+        X = dct_2d(torch.tensor(x).float())
+        y = idct_2d(X).numpy()
+        assert np.abs(x - y).max() < EPS, x
+
+
+def test_dct_3d():
+    for N1 in [2, 5, 32]:
+        x = np.random.normal(size=(1, N1, N1, N1))
+        ref = fftpack.dct(x, axis=3, type=2)
+        ref = fftpack.dct(ref, axis=2, type=2)
+        ref = fftpack.dct(ref, axis=1, type=2)
+        act = dct_3d(torch.tensor(x).float()).numpy()
+        assert np.abs(ref - act).max() < EPS, (ref, act)
+
+
+def test_idct_3d():
+    for N1 in [2, 5, 32]:
+            x = np.random.normal(size=(1, N1, N1, N1))
+            X = dct_3d(torch.tensor(x).float())
+            y = idct_3d(X).numpy()
+            assert np.abs(x - y).max() < EPS, x


### PR DESCRIPTION
Implementation of DCT as a linear layer, which will be faster on GPUs in general, but consumes more memory. Added tests for it, which pass, but the `EPS` has to be set much higher, to `1e-3`. I'm not sure why this is. It could be because it does the calculations in float32, while the original tests worked in float64.