### PR TITLE
Fix build on Travis CI and add Python 3.7 for the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - "3.5"
 - "3.6"
+- "3.7"
 #- "2.7"
 install:
 - pip install -r test_req.txt | cat

--- a/test_req.txt
+++ b/test_req.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=3.6
 pytest-runner
 pytest-cov
 codecov


### PR DESCRIPTION
Fixed build on Travis CI.

I'm not sure if Python 3.5 should be dropped, but I added Python 3.7 for the build.